### PR TITLE
Add alternative css mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export type TOptions = {
   slidesPerView?: number
   spacing?: number
   vertical?: boolean
+  inlineBlockMode?: boolean
 }
 
 export type TEvents = {

--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -196,6 +196,10 @@ function KeenSlider(initialContainer, initialOptions = {}) {
     return !!options.vertical
   }
 
+  function isInlineBlockMode() {
+    return !!options.inlineBlockMode;
+  }
+
   function moveAnimate() {
     reqId = window.requestAnimationFrame(moveAnimateUpdate)
   }
@@ -349,6 +353,9 @@ function KeenSlider(initialContainer, initialOptions = {}) {
     container = _container[0]
     sliderResize()
     eventsAdd()
+    if (!isVertialSlider() && isInlineBlockMode()) {
+      container.setAttribute('data-keen-inline-mode', true);
+    }
     hook('mounted')
   }
 
@@ -423,6 +430,13 @@ function KeenSlider(initialContainer, initialOptions = {}) {
   function sliderUnbind() {
     eventsRemove()
     slidesRemoveStyles()
+    let _container = getElements(initialContainer)
+    if (_container.length) {
+      container = _container[0]
+      if (container.hasAttribute('data-keen-inline-mode')) {
+        container.removeAttribute('data-keen-inline-mode');
+      }
+    }
     hook('destroyed')
   }
 
@@ -437,12 +451,25 @@ function KeenSlider(initialContainer, initialOptions = {}) {
 
   function slidesSetPositions() {
     if (!slides) return
+    console.log(trackSlidePositions);
     slides.forEach((slide, idx) => {
-      const absoluteDistance = trackSlidePositions[idx].distance * width
+      let absoluteDistance = trackSlidePositions[idx].distance * width
       const x = isVertialSlider() ? 0 : absoluteDistance
       const y = isVertialSlider() ? absoluteDistance : 0
-      slide.style.transform = `translate3d(${x}px, ${y}px, 0)`
-      slide.style['-webkit-transform'] = `translate3d(${x}px, ${y}px, 0)`
+      if (!isVertialSlider() && isInlineBlockMode()) {
+        const transformString = `translate3d(
+          calc(${x}px - calc(
+            ${idx} * calc(
+                ${(width / slidesPerView) - (spacing / slidesPerView)}px - ${(spacing / slidesPerView) * (slidesPerView - 1)}px
+              )
+            )
+          ), ${y}px, 0)`
+        slide.style.transform = transformString
+        slide.style['-webkit-transform'] = transformString
+      } else {
+        slide.style.transform = `translate3d(${x}px, ${y}px, 0)`
+        slide.style['-webkit-transform'] = `translate3d(${x}px, ${y}px, 0)`
+      }
     })
   }
 
@@ -642,6 +669,7 @@ function KeenSlider(initialContainer, initialOptions = {}) {
     spacing: 0,
     mode: 'snap',
     rubberband: true,
+    inlineBlockMode: false,
   }
 
   const pubfuncs = {

--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -453,7 +453,7 @@ function KeenSlider(initialContainer, initialOptions = {}) {
     if (!slides) return
     console.log(trackSlidePositions);
     slides.forEach((slide, idx) => {
-      let absoluteDistance = trackSlidePositions[idx].distance * width
+      const absoluteDistance = trackSlidePositions[idx].distance * width
       const x = isVertialSlider() ? 0 : absoluteDistance
       const y = isVertialSlider() ? absoluteDistance : 0
       if (!isVertialSlider() && isInlineBlockMode()) {

--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -451,7 +451,6 @@ function KeenSlider(initialContainer, initialOptions = {}) {
 
   function slidesSetPositions() {
     if (!slides) return
-    console.log(trackSlidePositions);
     slides.forEach((slide, idx) => {
       const absoluteDistance = trackSlidePositions[idx].distance * width
       const x = isVertialSlider() ? 0 : absoluteDistance

--- a/src/keen-slider.scss
+++ b/src/keen-slider.scss
@@ -23,3 +23,18 @@
 .keen-slider.keen-slider--vertical .keen-slider__slide {
   min-height: auto;
 }
+
+.keen-slider[data-keen-inline-mode] {
+  display: block;
+  overflow: auto;
+  max-width: 100vw;
+  white-space: nowrap;
+  overflow-y: hidden;
+  overflow-x: hidden;
+}
+.keen-slider[data-keen-inline-mode] > .keen-slider__slide {
+  position: relative;
+  display: inline-block;
+  overflow: visible;
+  white-space: normal;
+}

--- a/src/keen-slider.scss
+++ b/src/keen-slider.scss
@@ -35,6 +35,5 @@
 .keen-slider[data-keen-inline-mode] > .keen-slider__slide {
   position: relative;
   display: inline-block;
-  overflow: visible;
   white-space: normal;
 }


### PR DESCRIPTION
I had many problems because keen-slider works with position absolute. I added a way were you don't need to calculate the height of the slider. It uses `display: inline-block` and `position: relative`. However, for this to work I needed to change some calculations. `transform` works a bit different with `inline-block`. 

Note: this does not work with the vertical mode. 