### PR TITLE
Prevent event memory leak

### DIFF
--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -50,7 +50,7 @@ function KeenSlider(initialContainer, initialOptions = {}) {
 
   function eventAdd(element, event, handler, options = {}) {
     element.addEventListener(event, handler, options)
-    events.push([element, event, handler])
+    events.push([element, event, handler, options])
   }
 
   function eventDrag(e) {
@@ -179,8 +179,9 @@ function KeenSlider(initialContainer, initialOptions = {}) {
 
   function eventsRemove() {
     events.forEach(event => {
-      event[0].removeEventListener(event[1], event[2])
+      event[0].removeEventListener(event[1], event[2], event[3])
     })
+    events = []
   }
 
   function hook(hook) {

--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -1,10 +1,11 @@
 import './polyfills'
 
 function KeenSlider(initialContainer, initialOptions = {}) {
-  const events = []
   const attributeMoving = 'data-keen-slider-moves'
   const attributeVertical = 'data-keen-slider-v'
+  
   let container
+  let events = []
   let touchControls
   let length
   let origin


### PR DESCRIPTION
1. When `addEventListener` is called with option (capture),  the corresponding event needs to pass in the same options to be removed
1. Potential memory leak for `events` if we keep calling `sliderBind` (rebind events), the array size will just keep growing.