### PR TITLE
fix(slide-index): don't fire slideChanged when sliding where no slides are

### DIFF
--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -671,6 +671,10 @@ function KeenSlider(initialContainer, initialOptions = {}) {
   function trackSetCurrentIdx() {
     const new_idx = Math.round(trackPosition / (width / slidesPerView))
     if (new_idx === trackCurrentIdx) return
+    if (!isLoop()) {
+      if (new_idx < 0) return
+      if (new_idx > length - 1) return
+    }
     trackCurrentIdx = new_idx
     hook('slideChanged')
   }


### PR DESCRIPTION
Fix for https://github.com/rcbyr/keen-slider/issues/67