### PR TITLE
Add wheel scrolling support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ export type TOptions = {
   friction?: number
   initial?: number
   loop?: boolean
+  wheel?: boolean
   mode?: 'snap' | 'free' | 'free-snap'
   preventEvent?: string
   resetSlide?: boolean


### PR DESCRIPTION
The goal of this PR is to add wheel and trackpad scrolling support (or at least to work towards such support). Relates to issue #1.

To turn on wheel scrolling for your slides the user would pass an option `wheel: true` to the constructor.

Currently (in my tests on chrome on MacOS) the wheel scrolling seems to work in `free` and `free-snap` modes (in both vertical and horizontal configurations, and with different number of slides). Without `loop:true` the snapping maybe is not ideal on the edges. I think that even without `snap` mode support this feature can be useful.

More testing is necessary, but before doing more work on this I wanted to ask @rcbyr opinion on this. Is this the way you wanted to add wheel/trackpad scrolling support? Would this PR be considered, or is there already work done on this feature?
