### PR TITLE
Calculate offset based on fractional value

### DIFF
--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -444,7 +444,11 @@ function KeenSlider(initialContainer, initialOptions = {}) {
     const dragSpeed = options.dragSpeed
     touchMultiplicator =
       typeof dragSpeed === 'function' ? dragSpeed : val => val * dragSpeed
-    width = isVerticalSlider() ? container.offsetHeight : container.offsetWidth
+
+    const containerBoundingRect = container.getBoundingClientRect()
+
+    console.log('containerBoundingRect', containerBoundingRect)
+    width = isVerticalSlider() ? containerBoundingRect.height : containerBoundingRect.width
     slidesPerView = sliderGetSlidesPerView(options.slidesPerView)
     spacing = clampValue(options.spacing, 0, width / (slidesPerView - 1) - 1)
     width += spacing

--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -447,7 +447,6 @@ function KeenSlider(initialContainer, initialOptions = {}) {
 
     const containerBoundingRect = container.getBoundingClientRect()
 
-    console.log('containerBoundingRect', containerBoundingRect)
     width = isVerticalSlider() ? containerBoundingRect.height : containerBoundingRect.width
     slidesPerView = sliderGetSlidesPerView(options.slidesPerView)
     spacing = clampValue(options.spacing, 0, width / (slidesPerView - 1) - 1)


### PR DESCRIPTION
offsetWidth and offsetHeight return an integer value: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth

Because of this, the width calculation fails when the container contains a fractional value. 

Fixes #117 