### PR TITLE
Docs: class -> className & remove unnecessary rtl.

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -73,7 +73,6 @@ import { useKeenSlider } from 'keen-slider/react' // import from 'keen-slider/re
 export default () => {
   const [refCallback, slider, sliderNode] = useKeenSlider(
     {
-      rtl: true,
       slideChanged() {
         console.log('slide changed')
       },
@@ -85,9 +84,9 @@ export default () => {
 
   return (
     <div ref={refCallback} className="keen-slider">
-      <div class="keen-slider__slide">1</div>
-      <div class="keen-slider__slide">2</div>
-      <div class="keen-slider__slide">3</div>
+      <div className="keen-slider__slide">1</div>
+      <div className="keen-slider__slide">2</div>
+      <div className="keen-slider__slide">3</div>
     </div>
   )
 }
@@ -113,13 +112,13 @@ The library comes with a function that uses the composition API of Vue 3. Theref
 </script>
 
 <template>
-  <div ref="container" class="keen-slider">
-    <div class="keen-slider__slide number-slide1">1</div>
-    <div class="keen-slider__slide number-slide2">2</div>
-    <div class="keen-slider__slide number-slide3">3</div>
-    <div class="keen-slider__slide number-slide4">4</div>
-    <div class="keen-slider__slide number-slide5">5</div>
-    <div class="keen-slider__slide number-slide6">6</div>
+  <div ref="container" className="keen-slider">
+    <div className="keen-slider__slide number-slide1">1</div>
+    <div className="keen-slider__slide number-slide2">2</div>
+    <div className="keen-slider__slide number-slide3">3</div>
+    <div className="keen-slider__slide number-slide4">4</div>
+    <div className="keen-slider__slide number-slide5">5</div>
+    <div className="keen-slider__slide number-slide6">6</div>
   </div>
 </template>
 


### PR DESCRIPTION
These were small things I noticed when giving `keen-slider` a spin.