### PR TITLE
issue 181: make sure abs and rel are calculated correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keen-slider",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "The HTML touch slider carousel with the most native feeling you will get.",
   "main": "keen-slider.cjs.js",
   "jsnext:main": "keen-slider.es.js",

--- a/src/core/track.ts
+++ b/src/core/track.ts
@@ -144,7 +144,7 @@ export default function Track(
 
   function getIndexes(pos) {
     let factor = Math.floor(Math.abs(pos / length))
-    const positionRelative = ((pos % length) + length) % length
+    const positionRelative = round(((pos % length) + length) % length)
     const positionSign = sign(pos)
     const origin = relativePositions.indexOf(
       [...relativePositions].reduce((a, b) =>
@@ -256,7 +256,7 @@ export default function Track(
 
       distance -= val[2]
       if (acc[acc.length - 1] > distance) distance = acc[acc.length - 1]
-      acc.push(distance)
+      acc.push(round(distance))
       return acc
     }, null)
     relativePositions.push(length)


### PR DESCRIPTION
fixing: https://github.com/rcbyr/keen-slider/issues/195 and https://github.com/rcbyr/keen-slider/issues/181
all values: `a,b, positionRelative ` are by default in 6 fraction digits format

```
 Math.abs(b - positionRelative) < Math.abs(a - positionRelative) ? b : a
```
previously was buggy as it was comparing non unified values with different fraction digits

Can be tested in sandbox by using `@ponciusz/keen-slider` instead original one I published it on npm