### PR TITLE
Fix max-width/height values to be rounded in performance mode

### DIFF
--- a/src/plugins/web/renderer.ts
+++ b/src/plugins/web/renderer.ts
@@ -55,9 +55,12 @@ export default function Renderer(
 
   function scaleElement(element, value, vertical) {
     const type = vertical ? 'height' : 'width'
-    if (value !== null) value += 'px'
-    element.style['min-' + type] = value
-    element.style['max-' + type] = value
+    if (value !== null) {
+      if (slider.options.renderMode === 'performance') value = Math.round(value)
+      value += 'px'
+      element.style['min-' + type] = value
+      element.style['max-' + type] = value
+    }
   }
 
   function positionElement(element, value, vertical) {


### PR DESCRIPTION
`positionElement()` is rounding the translated values when in performance mode. However, `scaleElement()` is not.

This PR helps to fix the issue when images are scaled to half pixels, currently leaving an ugly line to the the right of the image (see zoomed in screenshot).

<img width="55" alt="CleanShot 2022-03-25 at 10 49 38@2x" src="https://user-images.githubusercontent.com/594971/160097227-f2f877aa-556c-4a7b-bf6b-500e59e7bf9c.png">
