### PR TITLE
Update React docs to match behavior

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -71,7 +71,7 @@ import 'keen-slider/keen-slider.min.css'
 import { useKeenSlider } from 'keen-slider/react' // import from 'keen-slider/react.es' for to get an ES module
 
 export default () => {
-  const [sliderRef, sliderInstance] = useKeenSlider(
+  const [sliderRef, instanceRef] = useKeenSlider(
     {
       slideChanged() {
         console.log('slide changed')

--- a/docs/web.md
+++ b/docs/web.md
@@ -71,7 +71,7 @@ import 'keen-slider/keen-slider.min.css'
 import { useKeenSlider } from 'keen-slider/react' // import from 'keen-slider/react.es' for to get an ES module
 
 export default () => {
-  const [refCallback, slider, sliderNode] = useKeenSlider(
+  const [sliderRef, sliderInstance] = useKeenSlider(
     {
       slideChanged() {
         console.log('slide changed')
@@ -83,7 +83,7 @@ export default () => {
   )
 
   return (
-    <div ref={refCallback} className="keen-slider">
+    <div ref={sliderRef} className="keen-slider">
       <div className="keen-slider__slide">1</div>
       <div className="keen-slider__slide">2</div>
       <div className="keen-slider__slide">3</div>


### PR DESCRIPTION
According to [the React docs](https://keen-slider.io/docs#usage-in-react), `useKeenSlider` returns a tuple only containing two items, not three as currently shown in the React example. I also renamed the two returned items to be a bit more clear, using some of the other examples for reference.