### PR TITLE
Fix recalculate layout issue

### DIFF
--- a/src/plugins/web/web.ts
+++ b/src/plugins/web/web.ts
@@ -46,7 +46,7 @@ export default function Web<O>(
       setAttr(
         slider.container,
         'reverse',
-        dir(slider.container) === 'rtl' && !remove ? '' : null
+        options.rtl && dir(slider.container) === 'rtl' && !remove ? '' : null
       )
       setAttr(
         slider.container,


### PR DESCRIPTION
<img width="520" alt="Screen Shot 2022-09-09 at 10 44 15 AM" src="https://user-images.githubusercontent.com/9281080/189274359-188b4c88-0805-480a-88f6-167d24434d06.png">

This code
https://github.com/rcbyr/keen-slider/blob/master/src/core/utils.ts?#L16

calling `getComputedStyle` which causes recalculated layout and makes a performance issue. So I make a condition to only check the direction if RTL option is enabled

Read more about it: https://gist.github.com/paulirish/5d52fb081b3570c81e3a
