### PR TITLE
Update type definition for selector option

### DIFF
--- a/src/plugins/web/types.ts
+++ b/src/plugins/web/types.ts
@@ -4,6 +4,9 @@ export interface WebOptions<O> {
   disabled?: boolean
   selector?:
     | string
+    | HTMLElement[]
+    | Nodelist
+    | HTMLCollection
     | ((
         container: HTMLElement
       ) => HTMLElement[] | NodeList | HTMLCollection | null)


### PR DESCRIPTION
The `selector` property in the `WebOptions` interface should accept lists of elements according to docs and implementation. 
This PR adds those types.