### PR TITLE
fix: update when either dimension of slider changes

### DIFF
--- a/src/plugins/web/types.ts
+++ b/src/plugins/web/types.ts
@@ -31,6 +31,7 @@ export interface WebInstance<O> {
   prev: () => void
   slides: HTMLElement[]
   size: number
+  crossSize: number
   update: (options?: O, idx?: number) => void
 }
 

--- a/src/plugins/web/web.ts
+++ b/src/plugins/web/web.ts
@@ -40,7 +40,7 @@ export default function Web<O>(
   ): void => {
     const events = Events()
 
-    let currentMatch, compareSize, options, mediaQueryLists
+    let currentMatch, compareSize, compareCrossSize, options, mediaQueryLists
 
     function applyAttributes(remove?) {
       setAttr(
@@ -102,6 +102,7 @@ export default function Web<O>(
       options = { ...defaultOptions, ..._options }
       events.purge()
       compareSize = slider.size
+      compareCrossSize = slider.crossSize
       mediaQueryLists = []
       for (const value in options.breakpoints || []) {
         const mediaQueryList: MediaQueryList & { __media?: string } =
@@ -198,8 +199,10 @@ export default function Web<O>(
     function resize() {
       updateSize()
       const newSize = slider.size
-      if (slider.options.disabled || newSize === compareSize) return
+      const newCrossSize = slider.crossSize
+      if (slider.options.disabled || (newSize === compareSize && newCrossSize === compareCrossSize)) return
       compareSize = newSize
+      compareCrossSize = newCrossSize
       update()
     }
 
@@ -212,6 +215,7 @@ export default function Web<O>(
     function updateSize() {
       const size = rect(slider.container)
       slider.size = (slider.options.vertical ? size.height : size.width) || 1
+      slider.crossSize = (slider.options.vertical ? size.width : size.height) || 1
     }
 
     function updateSlides() {


### PR DESCRIPTION
The `resize` event handler in `src/plugins/web/web.ts` skips calling `update` [if the size of the slider along its axis hasn't changed](https://github.com/rcbyr/keen-slider/blob/b5a3ddbcc95b75e12fce3a9d74f70cd70cf37ddc/src/plugins/web/web.ts#L201). Unfortunately, that doesn't handle the case where the slider's size only changes on the perpendicular axis.

For example: I have a horizontal slider across the entire page that's set to loop. The slides are square, and their size is capped to a fraction of the viewport height. If the window height is increased without changing the width, the slider gets taller, but it's still the same width - so it doesn't call `update`, and doesn't notice that the slides have gotten wider. As a result, the slides that have 'looped' to the left side start to shift to the right, overlapping other slides. If the window height is decreased instead, a gap appears between the looped slides and the others. The problem fixes itself as soon as the window width changes.

This pull request adds a `crossSize` property to (web) sliders, storing the size of the slider along its cross axis, and modifies the `resize` function to check it for changes in addition to the `size` property.

(I've based this off of v6.8.5, because an unrelated issue is preventing master from building. It should be okay to merge/rebase, but I wasn't able to test it.)