### PR TITLE
docs: Fix class attribute name in Vue example

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -112,13 +112,13 @@ The library comes with a function that uses the composition API of Vue 3. Theref
 </script>
 
 <template>
-  <div ref="container" className="keen-slider">
-    <div className="keen-slider__slide number-slide1">1</div>
-    <div className="keen-slider__slide number-slide2">2</div>
-    <div className="keen-slider__slide number-slide3">3</div>
-    <div className="keen-slider__slide number-slide4">4</div>
-    <div className="keen-slider__slide number-slide5">5</div>
-    <div className="keen-slider__slide number-slide6">6</div>
+  <div ref="container" class="keen-slider">
+    <div class="keen-slider__slide number-slide1">1</div>
+    <div class="keen-slider__slide number-slide2">2</div>
+    <div class="keen-slider__slide number-slide3">3</div>
+    <div class="keen-slider__slide number-slide4">4</div>
+    <div class="keen-slider__slide number-slide5">5</div>
+    <div class="keen-slider__slide number-slide6">6</div>
   </div>
 </template>
 


### PR DESCRIPTION
 `className` attribute in Vue html code example should be replaced with `class` attribute