### PR TITLE
Allow pinch zoom

### DIFF
--- a/src/keen-slider.scss
+++ b/src/keen-slider.scss
@@ -6,8 +6,8 @@
   user-select: none;
   -webkit-touch-callout: none;
   -khtml-user-select: none;
-  -ms-touch-action: pan-y;
-  touch-action: pan-y;
+  -ms-touch-action: pan-y pinch-zoom;
+  touch-action: pan-y pinch-zoom;
   -webkit-tap-highlight-color: transparent;
   width: 100%;
 

--- a/src/plugins/web/drag.ts
+++ b/src/plugins/web/drag.ts
@@ -52,6 +52,11 @@ export default function Drag(
 
     if (dragJustStarted) {
       if (!isSlide(e)) return dragStop(e)
+      if (
+        e.raw instanceof TouchEvent &&
+        e.raw.touches.length >= 2
+      )
+        return dragStop(e)
       lastValue = value
       dragJustStarted = false
       slider.emit('dragChecked')

--- a/src/plugins/web/drag.ts
+++ b/src/plugins/web/drag.ts
@@ -53,6 +53,7 @@ export default function Drag(
     if (dragJustStarted) {
       if (!isSlide(e)) return dragStop(e)
       if (
+        window.TouchEvent &&
         e.raw instanceof TouchEvent &&
         e.raw.touches.length >= 2
       )

--- a/src/plugins/web/types.ts
+++ b/src/plugins/web/types.ts
@@ -5,7 +5,7 @@ export interface WebOptions<O> {
   selector?:
     | string
     | HTMLElement[]
-    | Nodelist
+    | NodeList
     | HTMLCollection
     | ((
         container: HTMLElement


### PR DESCRIPTION
This allows pinch zoom when there are two or more fingers touching the surface before dragging. I don't know if this is the best way to solve this, but it seems to be working for me.

This is important to me so that users can zoom in to see the details of image slides.