### PR TITLE
fix: range should accept 0 as valid value

### DIFF
--- a/src/core/track.ts
+++ b/src/core/track.ts
@@ -39,8 +39,8 @@ export default function Track(
     loopMax = maxIdx = loop ? getProp(loop, 'max', infinity) : maxRelativeIdx
     const dragMin = getProp(rangeOption, 'min', null)
     const dragMax = getProp(rangeOption, 'max', null)
-    if (dragMin) minIdx = dragMin
-    if (dragMax) maxIdx = dragMax
+    if (dragMin !== null) minIdx = dragMin
+    if (dragMax !== null) maxIdx = dragMax
     min =
       minIdx === -infinity
         ? minIdx


### PR DESCRIPTION
In the function `setRange`, range values of `0` will be treated as falsy.
These should be valid, for example, if we want to show only the first slide.

Input:
```
slides: [1,2,3],
...
range: {
  min: 0,
  max: 0,
}
```

Output:
```
minIdx: 0,
maxIdx: 2,
```

Expected:
```
minIdx: 0,
maxIdx: 0,
```