### PR TITLE
Fix: third card item's right border not showing

### DIFF
--- a/src/plugins/web/web.ts
+++ b/src/plugins/web/web.ts
@@ -166,8 +166,8 @@ export default function Web<O>(
       for (let i = 0; i < slidesCount; i++) {
         const size =
           perView === 'auto'
-            ? getElementSize(elems[i])
-            : 1 / (perView as number) - spacing + spacingPortion
+            ? Math.floor(getElementSize(elems[i]))
+            : 1 / Math.floor((perView as number)) - spacing + spacingPortion
         const origin =
           originOption === 'center'
             ? 0.5 - size / 2


### PR DESCRIPTION
**Issue:** 

Outer right carousel item has its border hidden at certain screen widths:
<img width="885" alt="image" src="https://github.com/rcbyr/keen-slider/assets/69617566/7da361b4-611e-4542-b30f-b2d9c4ecf287">

**Cause**
When an odd number of cards are used in the carousel, the sum of all card widths and spacing exceeds the container so the outer right border of the last item is hidden due to the container's `overflow:hidden` css property (https://github.com/rcbyr/keen-slider/blob/master/src/keen-slider.scss)

For example, by overriding `keen-slider` 's css to `overflow: visible`, the border will show up again.

**Fix**
Round down the card size where it is not a whole number.



