### PR TITLE
feat: add origin params in moveToIdx

### DIFF
--- a/src/core/slider.ts
+++ b/src/core/slider.ts
@@ -23,8 +23,18 @@ function Slider<O, C, H extends string>(
     instance.emit('created')
   }
 
-  function moveToIdx(idx, absolute, animation) {
-    const distance = instance.track.idxToDist(idx, absolute)
+  function moveToIdx(idx, absolute, animation, origin?: 'auto' | 'center') {
+    let distance: number
+
+    if (!origin || origin === 'auto') {
+      distance = instance.track.idxToDist(idx, absolute)
+    } else {
+      const { distance: prevDistance, size } =
+        instance.track.details.slides[idx]
+      const elementCenter = prevDistance + size / 2
+      distance = Math.abs(0.5 - elementCenter)
+    }
+
     if (!distance) return
     const defaultAnimation = instance.options.defaultAnimation
     instance.animator.start([


### PR DESCRIPTION
## issue

First off, thank you for your wonderful library.

Even though I use the `origin='auto'` option, I want the element to be centered when I use the moveToIdx method.

So, as the fourth parameter of the moveToIdx method, `origin: 'auto' | I wrote code to center the element by adding 'center'`.

What do you think about this?