### PR TITLE
fix: handle cases when elements are in an iframe

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -65,7 +65,11 @@ export function elems(
     ? toArray(wrapper.querySelectorAll(elements))
     : elements instanceof HTMLElement
     ? [elements]
+    : elements instanceof elements.ownerDocument.defaultView.HTMLElement
+    ? [elements]
     : elements instanceof NodeList
+    ? toArray(elements)
+    : elements instanceof elements.ownerDocument.defaultView.NodeList
     ? toArray(elements)
     : []
 }


### PR DESCRIPTION
Fixes this issue https://github.com/rcbyr/keen-slider/issues/427. Related to this other issue on WordPress https://github.com/WordPress/gutenberg/issues/53867

And edge case is when an element exists in an iframe thus the Window object in the iframe will be different from the main Window. Thus thus comparison fails:
https://github.com/rcbyr/keen-slider/blob/b7aea40a7cb16032a04ad8a2df2b1c846c5a4f7d/src/core/utils.ts#L66
Iframes tend to be used by page builders such as gutenberg, grapesjs (I haven't tested it here), etc. that rely on iframes for isolation. The fix here fixes this issue.
Any edits are welcome.